### PR TITLE
Refactor game fetching to use top100in2weeks

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,20 +10,15 @@
     <header>
       <h1>Top Games by Combined Metacritic &amp; User Scores</h1>
       <p>
-        This page fetches the most popular PC games from Steam and ranks them
-        based on a combination of professional Metacritic scores and Steam user
-        ratings. Data is retrieved in real time via a Cloudflare Worker
-        proxy to avoid cross‑origin restrictions; please allow a few moments
-        for the scores to load.
+        This page fetches the 100 most-played PC games from the last two weeks
+        and ranks them based on a combination of professional Metacritic scores
+        and Steam user ratings. Data is retrieved in real time, so please allow
+        a few moments for the scores to load.
       </p>
     </header>
 
-    <!-- Controls for loading more results and searching -->
+    <!-- Controls for searching -->
     <div class="controls">
-      <!-- Button to load additional games. Initially hidden until data is loaded. -->
-      <button id="load-more" style="display: none;">
-        &#x2193; Load more
-      </button>
       <!-- Search input for finding a game by name. -->
       <input
         type="text"


### PR DESCRIPTION
This commit completely overhauls the game data fetching and ranking system.

The previous implementation used a paginated `request=all` from the SteamSpy API, which resulted in an outdated and irrelevant list of games. The loading was done in slow, sequential batches.

This new implementation:
- Fetches the top 100 most-played games in the last two weeks using the `top100in2weeks` endpoint.
- Fetches details for all 100 games concurrently for much-improved performance.
- Ranks the entire list based on a combined Metacritic and user score.
- Removes the "load more" functionality, as the entire curated list is loaded at once.
- Updates the UI and search functionality to align with the new system.