### PR TITLE
feat: Switch data source to top100forever for reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
   </head>
   <body>
     <header>
-      <h1>Top Games by Combined Metacritic &amp; User Scores</h1>
+      <h1>Top 100 All-Time Greats</h1>
       <p>
-        This page fetches the 100 most-played PC games from the last two weeks
-        and ranks them based on a combination of professional Metacritic scores
-        and Steam user ratings. Data is retrieved in real time, so please allow
-        a few moments for the scores to load.
+        This page fetches the top 100 most-played games of all time from
+        SteamSpy and ranks them based on a combination of professional
+        Metacritic scores and live Steam user ratings. The list of games is
+        updated daily, while the scores are fetched in real time.
       </p>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -152,8 +152,8 @@ async function loadTopGames() {
   listContainer.innerHTML = '<p>Loading data… please wait.</p>';
 
   try {
-    // Fetch the top 100 games from the last 2 weeks from SteamSpy.
-    const url = 'https://steamspy.com/api.php?request=top100in2weeks';
+    // Fetch the top 100 games of all time from SteamSpy.
+    const url = 'https://steamspy.com/api.php?request=top100forever';
     const candidateData = await fetchJson(url);
     const candidates = Object.values(candidateData);
 


### PR DESCRIPTION
This commit changes the data source from the `top100in2weeks` endpoint to the `top100forever` endpoint.

After your feedback and further investigation, it was determined that the `top100in2weeks` data was unreliable and not behaving as expected.

To provide a more stable and trustworthy list, the application now fetches the top 100 most-played games of all time. This list is a better foundation for ranking and aligns with your expectations for a list of "all-time greats".

The page title and description have been updated to reflect this new data source.